### PR TITLE
docs: add documentation for MyApp root widget

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,3 +1,7 @@
+///MyApp is the root widget of the application,
+///setting up the MaterialApp with a dark theme 
+///and routing to AuthGate as the home screen.
+
 import 'package:flutter/material.dart';
 import 'auth_gate.dart';
 


### PR DESCRIPTION
This patch adds documentation comments to app.dart to explain the root widget and AuthGate. Closes #1